### PR TITLE
Fix non message from h2

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,15 @@ export function activate(context: vscode.ExtensionContext) {
             const response = await fetch('https://www.estcequonmetenprodaujourdhui.info/');
             const text = await response.text();
             const $ = cheerio.load(text);
-            const message = $('body>div>strong').text();
-            statusBar.text = `$(rocket) ${message}`;
+            let message = $('body>div>strong').text();
+            let canDeploy = true;
+
+            if (!message) {
+                message = $('body>div>h2').text();
+                canDeploy = false;
+            }
+
+            statusBar.text = canDeploy ? `$(rocket) ${message}` : `$(x) ${message}`;
             vscode.window.showInformationMessage(message);
         } catch (error) {
             vscode.window.showErrorMessage('Failed to fetch deployment status.');


### PR DESCRIPTION
Fixes #1

Update the selector to fetch the message from `body>div>strong` and add a fallback to fetch from `body>div>h2` if the message is empty.

* Add a variable `canDeploy` and set it to `true` if the message is found in `body>div>strong`, otherwise set it to `false`.
* Update the status bar icon to a cross if `canDeploy` is `false`.
* Display the fetched message in the status bar and show an information message with the message content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/4skl/estcequonmetenprodaujourdhui/pull/2?shareId=224c4903-65f2-4642-b210-57c28dd9ae57).